### PR TITLE
fix undefined action name when logging outside of an action

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -3,7 +3,7 @@
 ## @adobe/aio-lib-core-logging
 
 * [@adobe/aio-lib-core-logging](#module_@adobe/aio-lib-core-logging)
-    * [module.exports(moduleName, config)](#exp_module_@adobe/aio-lib-core-logging--module.exports) ⏏
+    * [module.exports(moduleName, [config&#x3D;])](#exp_module_@adobe/aio-lib-core-logging--module.exports) ⏏
         * [~AioLogger](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger)
             * [new AioLogger(moduleName, [config])](#new_module_@adobe/aio-lib-core-logging--module.exports..AioLogger_new)
             * [.close()](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+close)
@@ -17,7 +17,7 @@
 
 <a name="exp_module_@adobe/aio-lib-core-logging--module.exports"></a>
 
-### module.exports(moduleName, config) ⏏
+### module.exports(moduleName, [config&#x3D;]) ⏏
 Creates a new AioLogger instance.
 
 **Kind**: Exported function  
@@ -25,7 +25,7 @@ Creates a new AioLogger instance.
 | Param | Type | Description |
 | --- | --- | --- |
 | moduleName | <code>string</code> | module name to be included with the log message. |
-| config | <code>AioLoggerConfig</code> | configuration for the log framework. |
+| [config=] |  | {AioLoggerConfig} configuration for the log framework. |
 
 <a name="module_@adobe/aio-lib-core-logging--module.exports..AioLogger"></a>
 
@@ -139,6 +139,8 @@ configuration for the log framework
 | Name | Type | Description |
 | --- | --- | --- |
 | [level] | <code>string</code> | logging level for winston, defaults to info |
+| [transports] | <code>string</code> | transport config for winston, defaults to undefined |
+| [silent] | <code>boolean</code> | silent config for winston, defaults to false |
 | [provider] | <code>string</code> | defaults to winston, can be set to either './WinstonLogger' or './DebugLogger' |
-| [logSourceAction] | <code>boolean</code> | default to true, if running in an action will log the action name, set to false to disable |
+| [logSourceAction] | <code>boolean</code> | defaults to true if __OW_ACTION_NAME is set otherwise defaults to false. If running in an action set logSourceAction to false if you do not want to log the action name. |
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -5,7 +5,7 @@
 * [@adobe/aio-lib-core-logging](#module_@adobe/aio-lib-core-logging)
     * [module.exports(moduleName, config)](#exp_module_@adobe/aio-lib-core-logging--module.exports) ⏏
         * [~AioLogger](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger)
-            * [new AioLogger(moduleName, config)](#new_module_@adobe/aio-lib-core-logging--module.exports..AioLogger_new)
+            * [new AioLogger(moduleName, [config])](#new_module_@adobe/aio-lib-core-logging--module.exports..AioLogger_new)
             * [.close()](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+close)
             * [.error(message)](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+error)
             * [.warn(message)](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+warn)
@@ -13,6 +13,7 @@
             * [.verbose(message)](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+verbose)
             * [.debug(message)](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+debug)
             * [.silly(message)](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+silly)
+        * [~AioLoggerConfig](#module_@adobe/aio-lib-core-logging--module.exports..AioLoggerConfig) : <code>object</code>
 
 <a name="exp_module_@adobe/aio-lib-core-logging--module.exports"></a>
 
@@ -24,7 +25,7 @@ Creates a new AioLogger instance.
 | Param | Type | Description |
 | --- | --- | --- |
 | moduleName | <code>string</code> | module name to be included with the log message. |
-| config | <code>string</code> | configuration for the log framework. |
+| config | <code>AioLoggerConfig</code> | configuration for the log framework. |
 
 <a name="module_@adobe/aio-lib-core-logging--module.exports..AioLogger"></a>
 
@@ -35,7 +36,7 @@ Winston is used by default.
 **Kind**: inner class of [<code>module.exports</code>](#exp_module_@adobe/aio-lib-core-logging--module.exports)  
 
 * [~AioLogger](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger)
-    * [new AioLogger(moduleName, config)](#new_module_@adobe/aio-lib-core-logging--module.exports..AioLogger_new)
+    * [new AioLogger(moduleName, [config])](#new_module_@adobe/aio-lib-core-logging--module.exports..AioLogger_new)
     * [.close()](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+close)
     * [.error(message)](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+error)
     * [.warn(message)](#module_@adobe/aio-lib-core-logging--module.exports..AioLogger+warn)
@@ -46,14 +47,14 @@ Winston is used by default.
 
 <a name="new_module_@adobe/aio-lib-core-logging--module.exports..AioLogger_new"></a>
 
-##### new AioLogger(moduleName, config)
+##### new AioLogger(moduleName, [config])
 Constructor
 
 
-| Param | Type | Description |
-| --- | --- | --- |
-| moduleName | <code>string</code> | module name to be included with the log message. |
-| config | <code>string</code> | configuration for the log framework. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| moduleName | <code>string</code> |  | module name to be included with the log message. |
+| [config] | <code>AioLoggerConfig</code> | <code>{}</code> | for the log framework. |
 
 <a name="module_@adobe/aio-lib-core-logging--module.exports..AioLogger+close"></a>
 
@@ -126,4 +127,18 @@ log silly message.
 | Param | Type | Description |
 | --- | --- | --- |
 | message | <code>string</code> | message to be logged. |
+
+<a name="module_@adobe/aio-lib-core-logging--module.exports..AioLoggerConfig"></a>
+
+#### module.exports~AioLoggerConfig : <code>object</code>
+configuration for the log framework
+
+**Kind**: inner typedef of [<code>module.exports</code>](#exp_module_@adobe/aio-lib-core-logging--module.exports)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| [level] | <code>string</code> | logging level for winston, defaults to info |
+| [provider] | <code>string</code> | defaults to winston, can be set to either './WinstonLogger' or './DebugLogger' |
+| [logSourceAction] | <code>boolean</code> | default to true, if running in an action will log the action name, set to false to disable |
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "lint": "eslint .",
     "docs": "jsdoc2md -f 'src/*.js' > doc/api.md"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/aio-lib-core-logging.git"
+  },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/AioLogger.js
+++ b/src/AioLogger.js
@@ -29,7 +29,6 @@ const DEFAULT_LABEL = 'AIO'
  * to disable
  */
 
-
 /**
 * This class provides a logging framework with pluggable logging provider.
 * Winston is used by default.

--- a/src/AioLogger.js
+++ b/src/AioLogger.js
@@ -19,14 +19,26 @@ const DEFAULT_LABEL = 'AIO'
  */
 
 /**
+ * configuration for the log framework
+ *
+ * @typedef AioLoggerConfig
+ * @type {object}
+ * @property {string} [level] logging level for winston, defaults to info
+ * @property {string} [provider] defaults to winston, can be set to either './WinstonLogger' or './DebugLogger'
+ * @property {boolean} [logSourceAction] default to true, if running in an action will log the action name, set to false
+ * to disable
+ */
+
+
+/**
 * This class provides a logging framework with pluggable logging provider.
 * Winston is used by default.
 */
 class AioLogger {
   /** Constructor
   *
-  * @param moduleName {string} module name to be included with the log message.
-  * @param config {string} configuration for the log framework.
+  * @param {string} moduleName  module name to be included with the log message.
+  * @param {AioLoggerConfig} [config={}] for the log framework.
   */
   constructor (moduleName, config = {}) {
     config = this.setDefaults(moduleName, config)
@@ -37,7 +49,7 @@ class AioLogger {
   setDefaults (moduleName, config) {
     config.level = config.level || DEFAULT_LEVEL
     config.provider = config.provider || DEFAULT_PROVIDER
-    config.logSourceAction = config.logSourceAction === undefined ? true : config.logSourceAction
+    config.logSourceAction = !!process.env.__OW_ACTION_NAME && config.logSourceAction !== false
     config.label = this.generateLabel(moduleName, config)
     return config
   }
@@ -109,7 +121,7 @@ class AioLogger {
   * Creates a new AioLogger instance.
   *
   * @param moduleName {string} module name to be included with the log message.
-  * @param config {string} configuration for the log framework.
+  * @param config {AioLoggerConfig} configuration for the log framework.
   * @function
  */
 module.exports = function (moduleName, config) {

--- a/src/WinstonLogger.js
+++ b/src/WinstonLogger.js
@@ -24,7 +24,7 @@ class WinstonLogger {
         this.getWinstonFormat()
       ),
       transports: this.getWinstonTransports(config.transports || DEFAULT_DEST),
-      silent: config.silent || false
+      silent: config.silent
     })
   }
 

--- a/test/AioLogger.test.js
+++ b/test/AioLogger.test.js
@@ -34,6 +34,7 @@ test('Debug', () => {
 })
 
 test('Winston', async () => {
+  process.env.__OW_ACTION_NAME = 'fake-action'
   fs.removeSync('./logfile.txt')
   fs.closeSync(fs.openSync('./logfile.txt', 'w'))
   let aioLogger = AioLogger()
@@ -45,7 +46,7 @@ test('Winston', async () => {
   aioLogger.silly('message')
   aioLogger.close()
   expect(global.console.log).toHaveBeenCalledTimes(3)
-  expect(global.console.log).toHaveBeenLastCalledWith(expect.stringContaining('[AIO undefined] info: message'))
+  expect(global.console.log).toHaveBeenLastCalledWith(expect.stringContaining('[AIO fake-action] info: message'))
 
   aioLogger = AioLogger('App', { transports: './logfile.txt', logSourceAction: false })
   aioLogger.error('logfile')

--- a/test/AioLogger.test.js
+++ b/test/AioLogger.test.js
@@ -14,6 +14,40 @@ const fs = require('fs-extra')
 
 afterEach(() => {
   jest.clearAllMocks()
+  delete process.env.__OW_ACTION_NAME
+  delete process.env.DEBUG
+})
+
+describe('config', () => {
+  test('when using defaults', () => {
+    const aioLogger = AioLogger('App')
+
+    expect(aioLogger.config.provider).toEqual('./WinstonLogger')
+    expect(aioLogger.config.level).toEqual('info')
+    expect(aioLogger.config.logSourceAction).toEqual(false)
+    expect(aioLogger.config.transports).toEqual(undefined)
+    expect(aioLogger.config.silent).toEqual(false)
+  })
+  test('when using defaults and __OW_ACTION_NAME is set', () => {
+    process.env.__OW_ACTION_NAME = 'fake-action'
+    const aioLogger = AioLogger('App')
+
+    expect(aioLogger.config.provider).toEqual('./WinstonLogger')
+    expect(aioLogger.config.level).toEqual('info')
+    expect(aioLogger.config.logSourceAction).toEqual(true)
+    expect(aioLogger.config.transports).toEqual(undefined)
+    expect(aioLogger.config.silent).toEqual(false)
+  })
+  test('when __OW_ACTION_NAME is set and config.logSourceAction = false', () => {
+    process.env.__OW_ACTION_NAME = 'fake-action'
+    const aioLogger = AioLogger('App', { logSourceAction: false })
+
+    expect(aioLogger.config.provider).toEqual('./WinstonLogger')
+    expect(aioLogger.config.level).toEqual('info')
+    expect(aioLogger.config.logSourceAction).toEqual(false)
+    expect(aioLogger.config.transports).toEqual(undefined)
+    expect(aioLogger.config.silent).toEqual(false)
+  })
 })
 
 test('Debug', () => {
@@ -29,8 +63,6 @@ test('Debug', () => {
   aioLogger.silly('message')
   aioLogger.close()
   expect(global.console.log).toHaveBeenCalledTimes(6)
-
-  delete process.env.DEBUG
 })
 
 test('Winston', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- if logging outside of an action get a label like `@adobe/aio-lib-core-tvm undefined:debug`
- instead this pr makes sure that if __OW_ACTION_NAME is not defined the label will be : `@adobe/aio-lib-core-tvm:debug`

- also added a jsdoc typedef for the config param
<!--- Describe your changes in detail -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
