### PR TITLE
change the way providers are required

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The config object can have one or more of the following keys.
 
 ```javascript
 // Winston Logger
-let aioLogger = require('@adobe/aio-lib-core-logging')('App', {provider:'./WinstonLogger'})
+let aioLogger = require('@adobe/aio-lib-core-logging')('App', {provider:'winston'})
 aioLogger.info('Hello logs')
 ```
 
@@ -52,7 +52,7 @@ or
 
 ```javascript
 // Debug Logger
-let aioLogger = require('@adobe/aio-lib-core-logging')('App', {provider:'./DebugLogger'})
+let aioLogger = require('@adobe/aio-lib-core-logging')('App', {provider:'debug'})
 ```
 
 ### Send logs to a file

--- a/doc/api.md
+++ b/doc/api.md
@@ -141,6 +141,6 @@ configuration for the log framework
 | [level] | <code>string</code> | logging level for winston, defaults to info |
 | [transports] | <code>string</code> | transport config for winston, defaults to undefined |
 | [silent] | <code>boolean</code> | silent config for winston, defaults to false |
-| [provider] | <code>string</code> | defaults to winston, can be set to either './WinstonLogger' or './DebugLogger' |
+| [provider] | <code>string</code> | defaults to winston, can be set to either 'winston' or 'debug' |
 | [logSourceAction] | <code>boolean</code> | defaults to true if __OW_ACTION_NAME is set otherwise defaults to false. If running in an action set logSourceAction to false if you do not want to log the action name. |
 

--- a/src/AioLogger.js
+++ b/src/AioLogger.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const DEFAULT_PROVIDER = './WinstonLogger'
+const DEFAULT_PROVIDER = 'winston'
 const DEFAULT_LEVEL = 'info'
 const DEFAULT_LABEL = 'AIO'
 
@@ -26,7 +26,7 @@ const DEFAULT_LABEL = 'AIO'
  * @property {string} [level] logging level for winston, defaults to info
  * @property {string} [transports] transport config for winston, defaults to undefined
  * @property {boolean} [silent] silent config for winston, defaults to false
- * @property {string} [provider] defaults to winston, can be set to either './WinstonLogger' or './DebugLogger'
+ * @property {string} [provider] defaults to winston, can be set to either 'winston' or 'debug'
  * @property {boolean} [logSourceAction] defaults to true if __OW_ACTION_NAME is set otherwise defaults to false. If
  * running in an action set logSourceAction to false if you do not want to log the action name.
  */
@@ -43,7 +43,9 @@ class AioLogger {
   */
   constructor (moduleName, config = {}) {
     this.setDefaults(moduleName, config)
-    this.LogProvider = require(this.config.provider)
+    if (this.config.provider === 'winston') this.LogProvider = require('./WinstonLogger')
+    else if (this.config.provider === 'debug') this.LogProvider = require('./DebugLogger')
+    else throw new Error(`log provider ${this.config.provider} is not supported, use one of [winston, debug]`)
     this.logger = new this.LogProvider(this.config)
   }
 

--- a/test/AioLogger.test.js
+++ b/test/AioLogger.test.js
@@ -22,7 +22,7 @@ describe('config', () => {
   test('when using defaults', () => {
     const aioLogger = AioLogger('App')
 
-    expect(aioLogger.config.provider).toEqual('./WinstonLogger')
+    expect(aioLogger.config.provider).toEqual('winston')
     expect(aioLogger.config.level).toEqual('info')
     expect(aioLogger.config.logSourceAction).toEqual(false)
     expect(aioLogger.config.transports).toEqual(undefined)
@@ -32,7 +32,7 @@ describe('config', () => {
     process.env.__OW_ACTION_NAME = 'fake-action'
     const aioLogger = AioLogger('App')
 
-    expect(aioLogger.config.provider).toEqual('./WinstonLogger')
+    expect(aioLogger.config.provider).toEqual('winston')
     expect(aioLogger.config.level).toEqual('info')
     expect(aioLogger.config.logSourceAction).toEqual(true)
     expect(aioLogger.config.transports).toEqual(undefined)
@@ -42,7 +42,7 @@ describe('config', () => {
     process.env.__OW_ACTION_NAME = 'fake-action'
     const aioLogger = AioLogger('App', { logSourceAction: false })
 
-    expect(aioLogger.config.provider).toEqual('./WinstonLogger')
+    expect(aioLogger.config.provider).toEqual('winston')
     expect(aioLogger.config.level).toEqual('info')
     expect(aioLogger.config.logSourceAction).toEqual(false)
     expect(aioLogger.config.transports).toEqual(undefined)
@@ -54,7 +54,7 @@ test('Debug', () => {
   process.env.DEBUG = '*'
 
   global.console = { log: jest.fn() }
-  const aioLogger = AioLogger('App', { provider: './DebugLogger' })
+  const aioLogger = AioLogger('App', { provider: 'debug' })
   aioLogger.error('message')
   aioLogger.warn('message')
   aioLogger.info('message')
@@ -99,4 +99,15 @@ test('Winston', async () => {
   aioLogger.error('logfile')
   aioLogger.close()
   expect(await getLog()).toContain('[App] error: logfile')
+})
+
+test('bad provider', async () => {
+  expect.hasAssertions()
+  try {
+    AioLogger('App', { provider: '__a_surely_not_supported_provider1234' })
+  } catch (e) {
+    expect(e.message).toEqual(expect.stringContaining('__a_surely_not_supported_provider1234'))
+    expect(e.message).toEqual(expect.stringContaining('winston'))
+    expect(e.message).toEqual(expect.stringContaining('debug'))
+  }
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a breaking change.

- rename providers: from './WinstonLogger' to 'winston' and './DebugLogger' to 'debug'
  => don't expose file names to end user

- remove the dynamic require `require(config.provider)`
  => avoid security issues where the user injects code into the require statement
  => by explicitly requiring `/WinstonLogger` and `./DebugLogger` bundlers such as parcel or webpack can follow the needed dependencies. (Dynamic require is a blocker for deploying TVM actions that depend on logger.)

<!--- Describe your changes in detail -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
