### PR TITLE
add: string substitution support

### DIFF
--- a/src/AioLogger.js
+++ b/src/AioLogger.js
@@ -77,50 +77,50 @@ class AioLogger {
 
   /** log error message.
   *
-  * @param message {string} message to be logged.
+  * @param {...string} messages message to be logged.
   */
-  error (message) {
-    this.logger.error(message)
+  error (...messages) {
+    this.logger.error(...messages)
   }
 
   /** log warn message.
   *
-  * @param message {string} message to be logged.
+  * @param {...string} messages message to be logged.
   */
-  warn (message) {
-    this.logger.warn(message)
+  warn (...messages) {
+    this.logger.warn(...messages)
   }
 
   /** log info message.
   *
-  * @param message {string} message to be logged.
+  * @param {...string} messages message to be logged.
   */
-  info (message) {
-    this.logger.info(message)
+  info (...messages) {
+    this.logger.info(...messages)
   }
 
   /** log verbose message.
   *
-  * @param message {string} message to be logged.
+  * @param {...string} messages message to be logged.
   */
-  verbose (message) {
-    this.logger.verbose(message)
+  verbose (...messages) {
+    this.logger.verbose(...messages)
   }
 
   /** log debug message.
   *
-  * @param message {string} message to be logged.
+  * @param {...string} messages message to be logged.
   */
-  debug (message) {
-    this.logger.debug(message)
+  debug (...messages) {
+    this.logger.debug(...messages)
   }
 
   /** log silly message.
   *
-  * @param message {string} message to be logged.
+  * @param {...string} messages message to be logged.
   */
-  silly (message) {
-    this.logger.silly(message)
+  silly (...messages) {
+    this.logger.silly(...messages)
   }
 }
 

--- a/src/DebugLogger.js
+++ b/src/DebugLogger.js
@@ -15,6 +15,7 @@ class DebugLogger {
   constructor (config) {
     this.config = config
     debug.formatters.s = this.getFormat()
+    debug.formatters.d = this.getFormat()
     debug.log = this.getDestination()
     debug.enable(this.getDebugLevel())
     this.errorLogger = debug(config.label).extend('error')

--- a/src/DebugLogger.js
+++ b/src/DebugLogger.js
@@ -87,8 +87,8 @@ class DebugLogger {
     this.debugLogger(...args)
   }
 
-  silly (message) {
-    this.sillyLogger('%s', message)
+  silly (...args) {
+    this.sillyLogger(...args)
   }
 }
 

--- a/src/WinstonLogger.js
+++ b/src/WinstonLogger.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const winston = require('winston')
-const { combine, timestamp, label } = winston.format
+const { combine, timestamp, label, splat } = winston.format
 const DEFAULT_DEST = 'console'
 
 class WinstonLogger {
@@ -20,6 +20,7 @@ class WinstonLogger {
       level: config.level,
       format: combine(
         label({ label: config.label }),
+        splat(),
         timestamp(),
         this.getWinstonFormat()
       ),
@@ -55,28 +56,28 @@ class WinstonLogger {
     this.logger.close()
   }
 
-  error (message) {
-    this.logger.error(message)
+  error (...args) {
+    this.logger.error(...args)
   }
 
-  warn (message) {
-    this.logger.warn(message)
+  warn (...args) {
+    this.logger.warn(...args)
   }
 
-  info (message) {
-    this.logger.info(message)
+  info (...args) {
+    this.logger.info(...args)
   }
 
-  verbose (message) {
-    this.logger.verbose(message)
+  verbose (...args) {
+    this.logger.verbose(...args)
   }
 
-  debug (message) {
-    this.logger.debug(message)
+  debug (...args) {
+    this.logger.debug(...args)
   }
 
-  silly (message) {
-    this.logger.silly(message)
+  silly (...args) {
+    this.logger.silly(...args)
   }
 }
 

--- a/test/AioLogger.test.js
+++ b/test/AioLogger.test.js
@@ -170,9 +170,9 @@ test('with Debug and level being silly', () => {
 test('debug with string substitution', () => {
   process.env.AIO_LOG_LEVEL = 'debug'
   const aioLogger = AioLogger('App', { provider: 'debug' })
-  aioLogger.info('message %s %s', 'hello', 'world')
+  aioLogger.info('message %s %s %d', 'hello', 'world', 123)
   expect(global.console.log).toHaveBeenLastCalledWith(
-    expect.stringContaining('message hello world')
+    expect.stringContaining('message hello world 123')
   )
 })
 
@@ -180,7 +180,7 @@ test('winston debug with string substitution', async () => {
   fs.removeSync('./logfile.txt')
   fs.closeSync(fs.openSync('./logfile.txt', 'w'))
   const aioLogger = AioLogger('App', { transports: './logfile.txt', logSourceAction: false })
-  aioLogger.info('message %s %s', 'hello', 'world')
+  aioLogger.info('message %s %s %d', 'hello', 'world', 123)
   aioLogger.close()
   function getLog () {
     return new Promise((resolve, reject) => {
@@ -191,5 +191,5 @@ test('winston debug with string substitution', async () => {
       }, 1000)
     })
   }
-  expect(await getLog()).toContain('message hello world')
+  expect(await getLog()).toContain('message hello world 123')
 })

--- a/test/AioLogger.test.js
+++ b/test/AioLogger.test.js
@@ -166,3 +166,30 @@ test('with Debug and level being silly', () => {
   aioLogger.silly('message')
   expect(global.console.log).toHaveBeenCalledTimes(2)
 })
+
+test('debug with string substitution', () => {
+  process.env.AIO_LOG_LEVEL = 'debug'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.info('message %s %s', 'hello', 'world')
+  expect(global.console.log).toHaveBeenLastCalledWith(
+    expect.stringContaining('message hello world')
+  )
+})
+
+test('winston debug with string substitution', async () => {
+  fs.removeSync('./logfile.txt')
+  fs.closeSync(fs.openSync('./logfile.txt', 'w'))
+  const aioLogger = AioLogger('App', { transports: './logfile.txt', logSourceAction: false })
+  aioLogger.info('message %s %s', 'hello', 'world')
+  aioLogger.close()
+  function getLog () {
+    return new Promise((resolve, reject) => {
+      setTimeout(function () {
+        const log = fs.readFileSync('./logfile.txt', 'utf8')
+        fs.removeSync('./logfile.txt')
+        resolve(log)
+      }, 1000)
+    })
+  }
+  expect(await getLog()).toContain('message hello world')
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding support for string substitutions in AioLogger
Both debug and winston logger will support string substitution

## Related Issue
Fix: #20 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- With unit tests
- local test implementations

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
