### PR TITLE
fix debug env

### DIFF
--- a/logfile.txt
+++ b/logfile.txt
@@ -1,1 +1,0 @@
-2020-08-31T17:50:18.954Z [App] error: logfile

--- a/logfile.txt
+++ b/logfile.txt
@@ -1,1 +1,0 @@
-2020-08-31T17:46:02.100Z [App] info: message hello world 123

--- a/logfile.txt
+++ b/logfile.txt
@@ -1,0 +1,1 @@
+2020-08-31T17:46:02.100Z [App] info: message hello world 123

--- a/logfile.txt
+++ b/logfile.txt
@@ -1,0 +1,1 @@
+2020-08-31T17:50:18.954Z [App] error: logfile

--- a/src/DebugLogger.js
+++ b/src/DebugLogger.js
@@ -17,12 +17,13 @@ class DebugLogger {
     debug.formatters.s = this.getFormat()
     debug.formatters.d = this.getFormat()
     debug.log = this.getDestination()
-    // make sure to take always take into account the latest DEBUG env var
+    // make sure to always take into account the latest DEBUG env var
     debug.enable(process.env.DEBUG)
     if (debug.enabled(this.config.label)) {
-      // => if we are here it means process.env.DEBUG === this.config.label || `${this.config.label}*`
+      // => if we are here it means process.env.DEBUG === this.config.label
+      // (`${this.config.label}*` will also match the condition but it will set all log levels anyways)
       // if let's say process.env.DEBUG === `${this.config.label}:debug` then we won't get
-      // into this branch and only warning logs will be shown
+      // into this branch and only debug logs will be shown
       debug.enable(this.getDebugLevel())
     }
     this.errorLogger = debug(config.label).extend('error')

--- a/src/DebugLogger.js
+++ b/src/DebugLogger.js
@@ -17,7 +17,14 @@ class DebugLogger {
     debug.formatters.s = this.getFormat()
     debug.formatters.d = this.getFormat()
     debug.log = this.getDestination()
-    debug.enable(this.getDebugLevel())
+    // make sure to take always take into account the latest DEBUG env var
+    debug.enable(process.env.DEBUG)
+    if (debug.enabled(this.config.label)) {
+      // => if we are here it means process.env.DEBUG === this.config.label || `${this.config.label}*`
+      // if let's say process.env.DEBUG === `${this.config.label}:debug` then we won't get
+      // into this branch and only warning logs will be shown
+      debug.enable(this.getDebugLevel())
+    }
     this.errorLogger = debug(config.label).extend('error')
     this.warnLogger = debug(config.label).extend('warn')
     this.infoLogger = debug(config.label).extend('info')
@@ -61,7 +68,7 @@ class DebugLogger {
         debugLevel = label + ':*'
         break
     }
-    return process.env.DEBUG ? process.env.DEBUG + ',' + debugLevel : debugLevel
+    return process.env.DEBUG + ',' + debugLevel
   }
 
   close () {

--- a/test/AioLogger.test.js
+++ b/test/AioLogger.test.js
@@ -262,6 +262,39 @@ test('with Debug and DEBUG=App and AIO_LOG_LEVEL=debug', () => {
   expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('verbose'))
   expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('debug'))
 })
+
+test('with Debug and DEBUG=App:debug and AIO_LOG_LEVEL=error', () => {
+  // here the log level is ignored and only debug logs will be shown
+  process.env.DEBUG = 'App:debug'
+  process.env.AIO_LOG_LEVEL = 'error'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(1)
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('debug'))
+})
+
+test('with Debug and DEBUG=App:warn and AIO_LOG_LEVEL=silly', () => {
+  // here the log level is ignored and only error logs will be shown
+  process.env.DEBUG = 'App:warn'
+  process.env.AIO_LOG_LEVEL = 'silly'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(1)
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('warn'))
+})
+
 test('with Debug and DEBUG=App and AIO_LOG_LEVEL=silly', () => {
   process.env.DEBUG = 'App'
   process.env.AIO_LOG_LEVEL = 'silly'

--- a/test/AioLogger.test.js
+++ b/test/AioLogger.test.js
@@ -12,8 +12,10 @@ governing permissions and limitations under the License.
 const AioLogger = require('../src/AioLogger')
 const fs = require('fs-extra')
 
-afterEach(() => {
-  jest.clearAllMocks()
+global.console = { log: jest.fn() }
+
+beforeEach(() => {
+  global.console.log.mockClear()
   delete process.env.__OW_ACTION_NAME
   delete process.env.DEBUG
   delete process.env.AIO_LOG_LEVEL
@@ -59,21 +61,6 @@ describe('config', () => {
     expect(aioLogger.config.transports).toEqual(undefined)
     expect(aioLogger.config.silent).toEqual(false)
   })
-})
-
-test('Debug', () => {
-  process.env.DEBUG = '*'
-
-  global.console = { log: jest.fn() }
-  const aioLogger = AioLogger('App', { provider: 'debug' })
-  aioLogger.error('message')
-  aioLogger.warn('message')
-  aioLogger.info('message')
-  aioLogger.verbose('message')
-  aioLogger.debug('message')
-  aioLogger.silly('message')
-  aioLogger.close()
-  expect(global.console.log).toHaveBeenCalledTimes(6)
 })
 
 test('Winston', async () => {
@@ -128,46 +115,195 @@ test('with Winston', () => {
   aioLogger.error('message')
   aioLogger.info('message')
   expect(global.console.log).toHaveBeenCalledTimes(1)
-  delete process.env.DEBUG
 })
-test('with Debug and level being error', () => {
+
+test('with Debug and DEBUG=*', () => {
+  process.env.DEBUG = '*'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(6)
+})
+test('with Debug and DEBUG=App:*', () => {
+  process.env.DEBUG = 'App:*'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(6)
+})
+test('with Debug and DEBUG=App*', () => {
+  process.env.DEBUG = 'App*'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(6)
+})
+test('with Debug and DEBUG=Ap*', () => {
+  process.env.DEBUG = 'App*'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(6)
+})
+test('with Debug and DEBUG=App and AIO_LOG_LEVEL', () => {
+  process.env.DEBUG = 'App'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  // info, warn, error
+  expect(global.console.log).toHaveBeenCalledTimes(3)
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('error'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('warn'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('info'))
+})
+test('with Debug and DEBUG=App and AIO_LOG_LEVEL=error', () => {
+  process.env.DEBUG = 'App'
   process.env.AIO_LOG_LEVEL = 'error'
   const aioLogger = AioLogger('App', { provider: 'debug' })
   aioLogger.error('message')
   aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
   expect(global.console.log).toHaveBeenCalledTimes(1)
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('error'))
 })
-test('with Debug and level being warn', () => {
+test('with Debug and DEBUG=App and AIO_LOG_LEVEL=warn', () => {
+  process.env.DEBUG = 'App'
   process.env.AIO_LOG_LEVEL = 'warn'
   const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
   aioLogger.warn('message')
   aioLogger.info('message')
-  expect(global.console.log).toHaveBeenCalledTimes(1)
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(2)
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('error'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('warn'))
 })
-test('with Debug and level being verbose', () => {
+test('with Debug and DEBUG=App and AIO_LOG_LEVEL=info', () => {
+  process.env.DEBUG = 'App'
+  process.env.AIO_LOG_LEVEL = 'info'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(3)
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('error'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('warn'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('info'))
+})
+test('with Debug and DEBUG=App and default AIO_LOG_LEVEL=verbose', () => {
+  process.env.DEBUG = 'App'
   process.env.AIO_LOG_LEVEL = 'verbose'
   const aioLogger = AioLogger('App', { provider: 'debug' })
-  aioLogger.verbose('message')
-  aioLogger.debug('message')
-  expect(global.console.log).toHaveBeenCalledTimes(1)
-})
-test('with Debug and level being debug', () => {
-  process.env.AIO_LOG_LEVEL = 'debug'
-  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
   aioLogger.verbose('message')
   aioLogger.debug('message')
   aioLogger.silly('message')
-  expect(global.console.log).toHaveBeenCalledTimes(2)
-})
-test('with Debug and level being silly', () => {
-  process.env.AIO_LOG_LEVEL = 'silly'
-  const aioLogger = AioLogger('App', { provider: 'debug' })
-  aioLogger.debug('message')
-  aioLogger.silly('message')
-  expect(global.console.log).toHaveBeenCalledTimes(2)
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(4)
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('error'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('warn'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('info'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('verbose'))
 })
 
-test('debug with string substitution', () => {
+test('with Debug and DEBUG=App and AIO_LOG_LEVEL=debug', () => {
+  process.env.DEBUG = 'App'
+  process.env.AIO_LOG_LEVEL = 'debug'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(5)
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('error'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('warn'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('info'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('verbose'))
+  expect(global.console.log).toHaveBeenCalledWith(expect.stringContaining('debug'))
+})
+test('with Debug and DEBUG=App and AIO_LOG_LEVEL=silly', () => {
+  process.env.DEBUG = 'App'
+  process.env.AIO_LOG_LEVEL = 'silly'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(6)
+})
+test('with Debug and DEBUG=Ap', () => {
+  process.env.DEBUG = 'Ap'
+  process.env.AIO_LOG_LEVEL = 'silly'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(0)
+})
+test('with Debug and DEBUG=Appnot', () => {
+  process.env.DEBUG = 'Apnot'
+  process.env.AIO_LOG_LEVEL = 'silly'
+  const aioLogger = AioLogger('App', { provider: 'debug' })
+  aioLogger.error('message')
+  aioLogger.warn('message')
+  aioLogger.info('message')
+  aioLogger.verbose('message')
+  aioLogger.debug('message')
+  aioLogger.silly('message')
+  aioLogger.close()
+  expect(global.console.log).toHaveBeenCalledTimes(0)
+})
+
+test('debug with string substitution and DEBUG=App', () => {
+  process.env.DEBUG = 'App'
   process.env.AIO_LOG_LEVEL = 'debug'
   const aioLogger = AioLogger('App', { provider: 'debug' })
   aioLogger.info('message %s %s %d', 'hello', 'world', 123)
@@ -176,20 +312,19 @@ test('debug with string substitution', () => {
   )
 })
 
-test('winston debug with string substitution', async () => {
+test('winston debug with string substitution and file transport', async () => {
+  // change-me: do not hit real file system and do not wait
+
   fs.removeSync('./logfile.txt')
   fs.closeSync(fs.openSync('./logfile.txt', 'w'))
   const aioLogger = AioLogger('App', { transports: './logfile.txt', logSourceAction: false })
   aioLogger.info('message %s %s %d', 'hello', 'world', 123)
   aioLogger.close()
-  function getLog () {
-    return new Promise((resolve, reject) => {
-      setTimeout(function () {
-        const log = fs.readFileSync('./logfile.txt', 'utf8')
-        fs.removeSync('./logfile.txt')
-        resolve(log)
-      }, 1000)
-    })
+  async function getLog () {
+    await new Promise((resolve, reject) => setTimeout(resolve, 100))
+    const log = fs.readFileSync('./logfile.txt', 'utf8')
+    fs.removeSync('./logfile.txt')
+    return log
   }
   expect(await getLog()).toContain('message hello world 123')
 })

--- a/test/AioLogger.test.js
+++ b/test/AioLogger.test.js
@@ -154,7 +154,7 @@ test('with Debug and DEBUG=App*', () => {
   expect(global.console.log).toHaveBeenCalledTimes(6)
 })
 test('with Debug and DEBUG=Ap*', () => {
-  process.env.DEBUG = 'App*'
+  process.env.DEBUG = 'Ap*'
   const aioLogger = AioLogger('App', { provider: 'debug' })
   aioLogger.error('message')
   aioLogger.warn('message')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
```javascript
let debugLogger = require('@adobe/aio-lib-core-logging')('App', {provider:'debug'})
debugLogger.error('blabla')
```
returns `App:error blabla` while the `DEBUG` environment variable is not set 

This leads to unexpected behaviours, for example in `aio-lib-state`, `aio-lib-files` and `aio-lib-core-tvm` an error will be always displayed, while libraries shouldn’t log anything by default.

This PR fixes this by making sure that the debug logger only shows logs if the `DEBUG` env var is set


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
